### PR TITLE
Allow aws-console icon font.

### DIFF
--- a/SansFonts.safariextension/blockerList.json
+++ b/SansFonts.safariextension/blockerList.json
@@ -91,5 +91,13 @@
         "trigger": {
             "url-filter": "fontastic"
         }
+    },
+    {
+        "action": {
+            "type": "ignore-previous-rules"
+        },
+        "trigger": {
+            "url-filter": "cloudfront.net\\/aws-console"
+        }
     }
 ]


### PR DESCRIPTION
In the AWS Console, they load their own icon font, and SansFonts was blocking it.

The URL was: https://d1sam4oyv1gqjr.cloudfront.net/aws-console-0bba89280839f9888d30eb6b2b0c55ba9d40a40c.woff
